### PR TITLE
Improve responsiveness and score persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Lato:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
 </head>
-<body>
+<body class="no-scroll">
     <!-- Portal de Inicio -->
     <div id="splash-screen">
         <div class="splash-content">
@@ -20,7 +20,7 @@
     </div>
 
     <!-- Contenido Principal del Juego -->
-    <main class="main-content" style="display: none;">
+    <main class="main-content">
         <h1>Juego de Memoria</h1>
         <div class="game-container">
             <div class="game-info">

--- a/netlify/functions/best-score.js
+++ b/netlify/functions/best-score.js
@@ -1,7 +1,7 @@
-const { getDeployStore } = require('@netlify/blobs');
+const { getStore } = require('@netlify/blobs');
 
 exports.handler = async (event) => {
-    const store = getDeployStore();
+    const store = getStore({ name: 'memory-game' });
     const key = 'best-score';
 
     if (event.httpMethod === 'GET') {

--- a/style.css
+++ b/style.css
@@ -16,12 +16,21 @@
     padding: 0;
 }
 
+html {
+    scroll-behavior: smooth;
+}
+
 body {
     font-family: var(--font-body);
-    background-color: var(--color-bg);
+    background: radial-gradient(circle at top, #222, var(--color-bg));
     color: var(--color-text);
     min-height: 100vh;
-    overflow: hidden; /* Evita el scroll mientras está el splash */
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+body.no-scroll {
+    overflow: hidden;
 }
 
 /* --- Portal de Inicio (Splash Screen) --- */
@@ -145,6 +154,7 @@ body {
     transform-style: preserve-3d;
     transition: transform 0.6s;
     cursor: pointer;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
 }
 
 .memory-card.flip {
@@ -244,5 +254,25 @@ body {
     }
     .main-content {
         padding-bottom: 90px; /* Más espacio en horizontal */
+    }
+}
+
+@media (min-width: 768px) {
+    .memory-game {
+        max-width: 600px;
+        gap: 1rem;
+    }
+}
+
+@media (min-width: 1024px) {
+    .memory-game {
+        max-width: 700px;
+        gap: 1.2rem;
+    }
+}
+
+@media (max-width: 360px) {
+    .memory-game {
+        gap: 0.3rem;
     }
 }


### PR DESCRIPTION
## Summary
- make game layout more responsive with additional media queries and card styling
- allow scrolling when necessary and remove scroll lock after starting
- fix best score persistence across devices via Netlify blob store and localStorage

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689434934a88832ba1be48df6b707633